### PR TITLE
Remove `eval` from `docker-entrypoint.sh`

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -48,12 +48,13 @@ if [ "$1" = 'redis-server' ]; then
 
 			if [ ! -x "$module" ]; then
 				echo "Warning: Module $module is not executable."
+				continue
 			fi
 			
-			command="$command --loadmodule $module"
+			set -- "$@" --loadmodule "$module"
 		done
 	fi
 fi
 
 
-eval "$command"
+exec "$@"

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -48,12 +48,13 @@ if [ "$1" = 'redis-server' ]; then
 
 			if [ ! -x "$module" ]; then
 				echo "Warning: Module $module is not executable."
+				continue
 			fi
 			
-			command="$command --loadmodule $module"
+			set -- "$@" --loadmodule "$module"
 		done
 	fi
 fi
 
 
-eval "$command"
+exec "$@"


### PR DESCRIPTION
This PR removes usage of `eval` in our `docker-entrypoint.sh` and uses `set --` with `exec` instead.