### PR TITLE
Release `6.2.17`, `7.2.7`, `7.4.2`

### DIFF
--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 6.2.16
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.16.tar.gz
-ENV REDIS_DOWNLOAD_SHA 846bff83c26d827d49f8cc8114ea9d1e72eea1169f7de36b8135ea2cec104e7d
+ENV REDIS_VERSION 6.2.17
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.17.tar.gz
+ENV REDIS_DOWNLOAD_SHA f7aab300407aaa005bc1a688e61287111f4ae13ed657ec50ef4ab529893ddc30
 
 RUN set -eux; \
 	\

--- a/6.2/debian/Dockerfile
+++ b/6.2/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 6.2.16
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.16.tar.gz
-ENV REDIS_DOWNLOAD_SHA 846bff83c26d827d49f8cc8114ea9d1e72eea1169f7de36b8135ea2cec104e7d
+ENV REDIS_VERSION 6.2.17
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.17.tar.gz
+ENV REDIS_DOWNLOAD_SHA f7aab300407aaa005bc1a688e61287111f4ae13ed657ec50ef4ab529893ddc30
 
 RUN set -eux; \
 	\

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.2.6
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.6.tar.gz
-ENV REDIS_DOWNLOAD_SHA fb10d67a2fe2b4556f6cb840064dd6e6e3175ce8ca035f0726990ec2da9f3d0e
+ENV REDIS_VERSION 7.2.7
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.7.tar.gz
+ENV REDIS_DOWNLOAD_SHA 72c081e3b8cfae7144273d26d76736f08319000af46c01515cad5d29765cead5
 
 RUN set -eux; \
 	\

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.2.6
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.6.tar.gz
-ENV REDIS_DOWNLOAD_SHA fb10d67a2fe2b4556f6cb840064dd6e6e3175ce8ca035f0726990ec2da9f3d0e
+ENV REDIS_VERSION 7.2.7
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.7.tar.gz
+ENV REDIS_DOWNLOAD_SHA 72c081e3b8cfae7144273d26d76736f08319000af46c01515cad5d29765cead5
 
 RUN set -eux; \
 	\

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.4.1
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.1.tar.gz
-ENV REDIS_DOWNLOAD_SHA bc34b878eb89421bbfca6fa78752343bf37af312a09eb0fae47c9575977dfaa2
+ENV REDIS_VERSION 7.4.2
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.2.tar.gz
+ENV REDIS_DOWNLOAD_SHA 4ddebbf09061cbb589011786febdb34f29767dd7f89dbe712d2b68e808af6a1f
 
 RUN set -eux; \
 	\

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.4.1
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.1.tar.gz
-ENV REDIS_DOWNLOAD_SHA bc34b878eb89421bbfca6fa78752343bf37af312a09eb0fae47c9575977dfaa2
+ENV REDIS_VERSION 7.4.2
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.2.tar.gz
+ENV REDIS_DOWNLOAD_SHA 4ddebbf09061cbb589011786febdb34f29767dd7f89dbe712d2b68e808af6a1f
 
 RUN set -eux; \
 	\

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
   "6.2": {
-    "version": "6.2.16",
-    "url": "http://download.redis.io/releases/redis-6.2.16.tar.gz",
-    "sha256": "846bff83c26d827d49f8cc8114ea9d1e72eea1169f7de36b8135ea2cec104e7d",
+    "version": "6.2.17",
+    "url": "http://download.redis.io/releases/redis-6.2.17.tar.gz",
+    "sha256": "f7aab300407aaa005bc1a688e61287111f4ae13ed657ec50ef4ab529893ddc30",
     "debian": {
       "version": "bookworm"
     },
@@ -112,9 +112,9 @@
     }
   },
   "7.2": {
-    "version": "7.2.6",
-    "url": "http://download.redis.io/releases/redis-7.2.6.tar.gz",
-    "sha256": "fb10d67a2fe2b4556f6cb840064dd6e6e3175ce8ca035f0726990ec2da9f3d0e",
+    "version": "7.2.7",
+    "url": "http://download.redis.io/releases/redis-7.2.7.tar.gz",
+    "sha256": "72c081e3b8cfae7144273d26d76736f08319000af46c01515cad5d29765cead5",
     "debian": {
       "version": "bookworm"
     },
@@ -224,9 +224,9 @@
     }
   },
   "7.4": {
-    "version": "7.4.1",
-    "url": "http://download.redis.io/releases/redis-7.4.1.tar.gz",
-    "sha256": "bc34b878eb89421bbfca6fa78752343bf37af312a09eb0fae47c9575977dfaa2",
+    "version": "7.4.2",
+    "url": "http://download.redis.io/releases/redis-7.4.2.tar.gz",
+    "sha256": "4ddebbf09061cbb589011786febdb34f29767dd7f89dbe712d2b68e808af6a1f",
     "debian": {
       "version": "bookworm"
     },


### PR DESCRIPTION
Release of the latest supported redis versions:
- https://github.com/redis/redis/releases/tag/6.2.17
- https://github.com/redis/redis/releases/tag/7.2.7
- https://github.com/redis/redis/releases/tag/7.4.2