### PR TITLE
Don't remove apk tools and related files

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -134,8 +134,7 @@ RUN set -eux; \
 		apk del --no-network .module-build-deps; \
 	fi; \
 	apk del --no-network .build-deps; \
-	apk --purge del apk-tools ; \
-	rm -fr ~/.cache/pip*  rm -f /sbin/apk && rm -rf /etc/apk && rm -rf /lib/apk && rm -rf /usr/share/apk && rm -rf /var/lib/apk && rm -rf /usr/lib/python*; \
+	rm -rf ~/.cache ~/.gitconfig; \
 	\
 	redis-cli --version; \
 	redis-server --version;


### PR DESCRIPTION
Fixes: https://github.com/redis/docker-library-redis/issues/444

Do not remove apk-tools package and any related files
Fixed removal command to remove only relevant directories
