### PR TITLE
Bump Redis versions

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.2.8
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.8.tar.gz
-ENV REDIS_DOWNLOAD_SHA 6be4fdfcdb2e5ac91454438246d00842d2671f792673390e742dfcaf1bf01574
+ENV REDIS_VERSION 7.2.9
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.9.tar.gz
+ENV REDIS_DOWNLOAD_SHA 2343cc49db3beb9d2925a44e13032805a608821a58f25bd874c84881115a20b7
 
 RUN set -eux; \
 	\

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.2.8
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.8.tar.gz
-ENV REDIS_DOWNLOAD_SHA 6be4fdfcdb2e5ac91454438246d00842d2671f792673390e742dfcaf1bf01574
+ENV REDIS_VERSION 7.2.9
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.9.tar.gz
+ENV REDIS_DOWNLOAD_SHA 2343cc49db3beb9d2925a44e13032805a608821a58f25bd874c84881115a20b7
 
 RUN set -eux; \
 	\

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.4.3
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.3.tar.gz
-ENV REDIS_DOWNLOAD_SHA e1807d7c0f824f4c5450244ef50c1e596b8d09b35d03a83f4e018fb7316acf45
+ENV REDIS_VERSION 7.4.4
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.4.tar.gz
+ENV REDIS_DOWNLOAD_SHA 985c465146453f4d79912e70b2dc516577a1667cbf9b0420a0c87878fcc6f32f
 
 RUN set -eux; \
 	\

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.4.3
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.3.tar.gz
-ENV REDIS_DOWNLOAD_SHA e1807d7c0f824f4c5450244ef50c1e596b8d09b35d03a83f4e018fb7316acf45
+ENV REDIS_VERSION 7.4.4
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.4.tar.gz
+ENV REDIS_DOWNLOAD_SHA 985c465146453f4d79912e70b2dc516577a1667cbf9b0420a0c87878fcc6f32f
 
 RUN set -eux; \
 	\

--- a/versions.json
+++ b/versions.json
@@ -112,9 +112,9 @@
     }
   },
   "7.2": {
-    "version": "7.2.8",
-    "url": "http://download.redis.io/releases/redis-7.2.8.tar.gz",
-    "sha256": "6be4fdfcdb2e5ac91454438246d00842d2671f792673390e742dfcaf1bf01574",
+    "version": "7.2.9",
+    "url": "http://download.redis.io/releases/redis-7.2.9.tar.gz",
+    "sha256": "2343cc49db3beb9d2925a44e13032805a608821a58f25bd874c84881115a20b7",
     "debian": {
       "version": "bookworm"
     },
@@ -224,9 +224,9 @@
     }
   },
   "7.4": {
-    "version": "7.4.3",
-    "url": "http://download.redis.io/releases/redis-7.4.3.tar.gz",
-    "sha256": "e1807d7c0f824f4c5450244ef50c1e596b8d09b35d03a83f4e018fb7316acf45",
+    "version": "7.4.4",
+    "url": "http://download.redis.io/releases/redis-7.4.4.tar.gz",
+    "sha256": "985c465146453f4d79912e70b2dc516577a1667cbf9b0420a0c87878fcc6f32f",
     "debian": {
       "version": "bookworm"
     },


### PR DESCRIPTION
1. Redis 7.2: 7.2.8 -> 7.2.9: https://github.com/redis/redis/releases/tag/7.2.9
2. Redis 7.4: 7.4.3 -> 7.4.4: https://github.com/redis/redis/releases/tag/7.4.4