### PR TITLE
Update Redis to 8.0.3

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,8 +14,8 @@ RUN set -eux; \
 # we need setpriv package as busybox provides very limited functionality
 		setpriv \
 	;
-ENV REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.0.2.tar.gz
-ENV REDIS_DOWNLOAD_SHA=caf3c0069f06fc84c5153bd2a348b204c578de80490c73857bee01d9b5d7401f
+ENV REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.0.3.tar.gz
+ENV REDIS_DOWNLOAD_SHA=2467b9608ecbcc2c0d27397c0c2406b499b6f68bc08ac9f6380b1faf2113ae6f
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,8 +14,8 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.0.2.tar.gz
-ENV REDIS_DOWNLOAD_SHA=caf3c0069f06fc84c5153bd2a348b204c578de80490c73857bee01d9b5d7401f
+ENV REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.0.3.tar.gz
+ENV REDIS_DOWNLOAD_SHA=2467b9608ecbcc2c0d27397c0c2406b499b6f68bc08ac9f6380b1faf2113ae6f
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \


### PR DESCRIPTION
- Update download URL and SHA for Redis 8.0.3 release
- Security fixes: CVE-2025-32023 and CVE-2025-48367
- New VSIM WITHATTRIBS feature
- Bug fixes for replica short reads and db->expires defragmentation