### PR TITLE
alpine,debian: ensure modules build has llvm+libclang available

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		libffi-dev \
 		libgcc \
 		libtool \
+		llvm \
 		llvm-dev \
 		ncurses-dev \
 		openssh \
@@ -67,6 +68,9 @@ RUN set -eux; \
 		which \
 		xsimd \
 		xz; \
+	# Make llvm-config and libclang discoverable for clang-sys (Rust) \
+	export LLVM_CONFIG_PATH="$(command -v llvm-config || true)"; \
+	if [ -e /usr/lib/libclang.so ]; then export LIBCLANG_PATH="/usr/lib"; fi; \
 	fi; \
 	\
 # install required python packages for RedisJSON module

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -46,6 +46,9 @@ RUN set -eux; \
 			unzip \
 			rsync \
 			clang \
+			llvm \
+			llvm-dev \
+			libclang-dev \
 			automake \
 			autoconf \
 			libtool \


### PR DESCRIPTION
This PR fixes module builds failing due to missing llvm-config/libclang when BUILD_WITH_MODULES=yes.

- Alpine: add `llvm` (in addition to existing `llvm-dev`, `clang-libclang`) and export `LLVM_CONFIG_PATH` and `LIBCLANG_PATH` so `clang-sys` can locate toolchain.
- Debian: add `llvm`, `llvm-dev`, `libclang-dev` for the module build path.

Local verification:
- Built `alpine` (arm64) with modules: RediSearch, RedisJSON etc. linked successfully, no `clang-sys` errors.
- Built `debian` (arm64) with modules: completed successfully.

These changes should stabilize CI jobs where modules are enabled (amd64/arm64).