### PR TITLE
alpine,debian: fix tests/modules race on non-module arches; make pip conditional in Alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -29,9 +29,9 @@ RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	case "$arch" in \
-		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no ;; \
+		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes; export MAKE_JOBS="$(nproc)" ;; \
+		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes; export MAKE_JOBS="$(nproc)" ;; \
+		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no; export MAKE_JOBS=1 ;; \
 	esac; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 	apk add --no-cache --virtual .module-build-deps \
@@ -71,10 +71,11 @@ RUN set -eux; \
 	# Make llvm-config and libclang discoverable for clang-sys (Rust) \
 	export LLVM_CONFIG_PATH="$(command -v llvm-config || true)"; \
 	if [ -e /usr/lib/libclang.so ]; then export LIBCLANG_PATH="/usr/lib"; fi; \
+	# install required python packages for RedisJSON module
+	python3 -m pip -q install --upgrade pip setuptools; \
+	PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip -q install addict toml jinja2 ramp-packer; \
 	fi; \
 	\
-# install required python packages for RedisJSON module
-	pip install -q --upgrade setuptools &&  pip install -q --upgrade pip && PIP_BREAK_SYSTEM_PACKAGES=1 pip install -q addict toml jinja2 ramp-packer ;\
 	wget -O redis.tar.gz "$REDIS_DOWNLOAD_URL"; \
 	mkdir -p /usr/src/redis; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
@@ -123,7 +124,7 @@ RUN set -eux; \
 		sed -i 's/^RUST_FLAGS=$/RUST_FLAGS += -C target-feature=-crt-static/' /usr/src/redis/modules/redisjson/src/Makefile ; \
 		grep -E 'RUST_FLAGS' /usr/src/redis/modules/redisjson/src/Makefile; \
 	fi; \
-	make -C /usr/src/redis -j "$(nproc)" all; \
+	make -C /usr/src/redis -j "${MAKE_JOBS:-$(nproc)}" all; \
 	make -C /usr/src/redis install; \
 	\
 # TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -31,9 +31,9 @@ RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	case "$arch" in \
-		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no ;; \
+		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes; export MAKE_JOBS="$(nproc)" ;; \
+		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes; export MAKE_JOBS="$(nproc)" ;; \
+		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no; export MAKE_JOBS=1 ;; \
 	esac; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		apt-get install -y --no-install-recommends \
@@ -95,7 +95,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/redis/deps/Makefile; \
 	\
 	export BUILD_TLS=yes; \
-	make -C /usr/src/redis -j "$(nproc)" all; \
+	make -C /usr/src/redis -j "${MAKE_JOBS:-$(nproc)}" all; \
 	make -C /usr/src/redis install; \
 	\
 # TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)


### PR DESCRIPTION
Summary
- Avoid tests/modules race on non-module arches by limiting parallelism
  - Introduces MAKE_JOBS: amd64/arm64 keep full parallelism (-j nproc); all others use -j1
  - Fixes intermittent ld: cannot find commandfilter.xo (seen on arm/v6,v7 and other slow/emu arches)
- Alpine: call pip only when BUILD_WITH_MODULES=yes and use `python3 -m pip`

Verification (local, via colima + buildx + binfmt)
- Alpine: linux/arm/v6 — OK
- Alpine: linux/arm/v7 — OK
- Debian: linux/arm/v7 — OK

Notes
- This addresses failures that varied across OS/arch due to timing; serializing test module build removes the race without penalizing amd64/arm64 builds where modules are enabled.

Co-authored-by: Augment Code <https://www.augmentcode.com/>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author