### PR TITLE
Update redis to 6.2.20, 7.2.11 and 7.4.6

### DIFF
--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 6.2.19
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.19.tar.gz
-ENV REDIS_DOWNLOAD_SHA 73be4202261c2e2e3534ec2c3dcfbb338cceff40481ecf46c3578cb9e5fdea74
+ENV REDIS_VERSION 6.2.20
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.20.tar.gz
+ENV REDIS_DOWNLOAD_SHA 7f8b8a7aed53c445a877adf9e3743cdd323518524170135a58c0702f2dba6ef4
 
 RUN set -eux; \
 	\

--- a/6.2/debian/Dockerfile
+++ b/6.2/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 6.2.19
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.19.tar.gz
-ENV REDIS_DOWNLOAD_SHA 73be4202261c2e2e3534ec2c3dcfbb338cceff40481ecf46c3578cb9e5fdea74
+ENV REDIS_VERSION 6.2.20
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-6.2.20.tar.gz
+ENV REDIS_DOWNLOAD_SHA 7f8b8a7aed53c445a877adf9e3743cdd323518524170135a58c0702f2dba6ef4
 
 RUN set -eux; \
 	\

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.2.10
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.10.tar.gz
-ENV REDIS_DOWNLOAD_SHA e576ad54bc53770649c556933ecd555b975e3dac422e46356102436a437b43c7
+ENV REDIS_VERSION 7.2.11
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.11.tar.gz
+ENV REDIS_DOWNLOAD_SHA 2f9886eca68d30114ad6a01da65631f8007d802fd3e6c9fac711251e6390323d
 
 RUN set -eux; \
 	\

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.2.10
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.10.tar.gz
-ENV REDIS_DOWNLOAD_SHA e576ad54bc53770649c556933ecd555b975e3dac422e46356102436a437b43c7
+ENV REDIS_VERSION 7.2.11
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.2.11.tar.gz
+ENV REDIS_DOWNLOAD_SHA 2f9886eca68d30114ad6a01da65631f8007d802fd3e6c9fac711251e6390323d
 
 RUN set -eux; \
 	\

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -49,9 +49,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.4.5
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.5.tar.gz
-ENV REDIS_DOWNLOAD_SHA 00bb280528f5d7934bec8ab309b8125088c209131e10609cb1563b91365633bb
+ENV REDIS_VERSION 7.4.6
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.6.tar.gz
+ENV REDIS_DOWNLOAD_SHA 73b94484e00fb4c2440b490dc4021142fb0b6efc8b64c6329c10d24f0b531c99
 
 RUN set -eux; \
 	\

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -56,9 +56,9 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-ENV REDIS_VERSION 7.4.5
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.5.tar.gz
-ENV REDIS_DOWNLOAD_SHA 00bb280528f5d7934bec8ab309b8125088c209131e10609cb1563b91365633bb
+ENV REDIS_VERSION 7.4.6
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-7.4.6.tar.gz
+ENV REDIS_DOWNLOAD_SHA 73b94484e00fb4c2440b490dc4021142fb0b6efc8b64c6329c10d24f0b531c99
 
 RUN set -eux; \
 	\

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
   "6.2": {
-    "version": "6.2.19",
-    "url": "http://download.redis.io/releases/redis-6.2.19.tar.gz",
-    "sha256": "73be4202261c2e2e3534ec2c3dcfbb338cceff40481ecf46c3578cb9e5fdea74",
+    "version": "6.2.20",
+    "url": "http://download.redis.io/releases/redis-6.2.20.tar.gz",
+    "sha256": "7f8b8a7aed53c445a877adf9e3743cdd323518524170135a58c0702f2dba6ef4",
     "debian": {
       "version": "bookworm"
     },
@@ -112,9 +112,9 @@
     }
   },
   "7.2": {
-    "version": "7.2.10",
-    "url": "http://download.redis.io/releases/redis-7.2.10.tar.gz",
-    "sha256": "e576ad54bc53770649c556933ecd555b975e3dac422e46356102436a437b43c7",
+    "version": "7.2.11",
+    "url": "http://download.redis.io/releases/redis-7.2.11.tar.gz",
+    "sha256": "2f9886eca68d30114ad6a01da65631f8007d802fd3e6c9fac711251e6390323d",
     "debian": {
       "version": "bookworm"
     },
@@ -224,9 +224,9 @@
     }
   },
   "7.4": {
-    "version": "7.4.5",
-    "url": "http://download.redis.io/releases/redis-7.4.5.tar.gz",
-    "sha256": "00bb280528f5d7934bec8ab309b8125088c209131e10609cb1563b91365633bb",
+    "version": "7.4.6",
+    "url": "http://download.redis.io/releases/redis-7.4.6.tar.gz",
+    "sha256": "73b94484e00fb4c2440b490dc4021142fb0b6efc8b64c6329c10d24f0b531c99",
     "debian": {
       "version": "bookworm"
     },


### PR DESCRIPTION
(CVE-2025-49844) A Lua script may lead to remote code execution
(CVE-2025-46817) A Lua script may lead to integer overflow and potential RCE
(CVE-2025-46818) A Lua script can be executed in the context of another user
(CVE-2025-46819) LUA out-of-bound read