### PR TITLE
Fix per-distro Stackbrew major aliases

### DIFF
--- a/release-automation/src/stackbrew_generator/cli.py
+++ b/release-automation/src/stackbrew_generator/cli.py
@@ -88,9 +88,11 @@ def _generate_stackbrew_content(major_version: int, remote: str, verbose: bool) 
         raise typer.Exit(1)
 
     # Generate stackbrew library content
+    is_highest_remote_major = major_version == highest_remote_major
     entries = stackbrew_generator.generate_stackbrew_library(
         releases,
-        enable_global_latest_tags=(major_version == highest_remote_major),
+        emit_global_latest=is_highest_remote_major,
+        emit_bare_aliases=is_highest_remote_major,
     )
     output = stackbrew_generator.format_stackbrew_output(entries)
 
@@ -225,9 +227,11 @@ def generate_image_tags(
         refs_to_fetch = [commit for _, commit, _ in versions]
         git_client.fetch_refs(refs_to_fetch)
         releases = distribution_detector.prepare_releases_list(versions)
+        is_highest_remote_major = redis_version.major == highest_remote_major
         entries = stackbrew_generator.generate_stackbrew_library(
             releases,
-            enable_global_latest_tags=(redis_version.major == highest_remote_major),
+            emit_global_latest=is_highest_remote_major,
+            emit_bare_aliases=is_highest_remote_major,
         )
 
         tags = ""

--- a/release-automation/src/stackbrew_generator/stackbrew.py
+++ b/release-automation/src/stackbrew_generator/stackbrew.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from rich.console import Console
 
@@ -17,20 +17,20 @@ class StackbrewGenerator:
     def generate_tags_for_release(
         self,
         release: Release,
-        is_latest_in_major: bool = False,
-        is_global_latest_major: bool = False,
-        latest_distro_tag_names: Optional[Set[str]] = None,
-        bare_distro_tag_names: Optional[Set[str]] = None,
+        is_latest_minor: bool = False,
+        emit_global_latest: bool = False,
+        major_alias_distro_names: Optional[Set[str]] = None,
+        bare_alias_distro_names: Optional[Set[str]] = None,
     ) -> List[str]:
         """Generate Docker tags for a release.
 
         Args:
             release: Release to generate tags for
-            is_latest_in_major: Whether this is the latest active minor in its major
-            is_global_latest_major: Whether this major is the highest active major overall
-            latest_distro_tag_names: Distro tag names whose major aliases belong to
+            is_latest_minor: Whether this is the latest active minor in its major
+            emit_global_latest: Whether to emit the global "latest" alias
+            major_alias_distro_names: Distro names whose major aliases belong to
                 this release
-            bare_distro_tag_names: Bare distro aliases that belong to this release
+            bare_alias_distro_names: Bare distro aliases that belong to this release
 
         Returns:
             List of Docker tags
@@ -50,18 +50,18 @@ class StackbrewGenerator:
         # This lets an older maintained distro release own (for example)
         # "8-bookworm" without also owning the unqualified "8" tag.
         default_version_tags = version_tags.copy()
-        if is_latest_in_major:
+        if is_latest_minor:
             default_version_tags.append(str(version.major))
 
         # Preserve the direct-call behavior used by existing callers and tests:
-        # a release that is globally latest owns all of its distro major aliases.
-        if latest_distro_tag_names is None:
-            latest_distro_tag_names = (
-                set(distribution.tag_names) if is_latest_in_major else set()
+        # the latest minor owns all of its distro-qualified major aliases.
+        if major_alias_distro_names is None:
+            major_alias_distro_names = (
+                set(distribution.tag_names) if is_latest_minor else set()
             )
-        if bare_distro_tag_names is None:
-            bare_distro_tag_names = (
-                set(distribution.tag_names) if is_global_latest_major else set()
+        if bare_alias_distro_names is None:
+            bare_alias_distro_names = (
+                set(distribution.tag_names) if emit_global_latest else set()
             )
 
         # For default distribution (Debian), add version tags without distro suffix
@@ -71,35 +71,67 @@ class StackbrewGenerator:
         # Add distro-specific tags
         for distro_name in distribution.tag_names:
             distro_version_tags = version_tags.copy()
-            if distro_name in latest_distro_tag_names:
+            if distro_name in major_alias_distro_names:
                 distro_version_tags.append(str(version.major))
 
             for version_tag in distro_version_tags:
                 tags.append(f"{version_tag}-{distro_name}")
 
         # The global "latest" alias remains on the newest default image only.
-        if is_global_latest_major and distribution.is_default:
+        if emit_global_latest and distribution.is_default:
             tags.append("latest")
 
         # Bare distro aliases belong to the newest release supporting each distro.
         tags.extend(
             distro_name
             for distro_name in distribution.tag_names
-            if distro_name in bare_distro_tag_names
+            if distro_name in bare_alias_distro_names
         )
 
         return tags
 
+    @staticmethod
+    def _release_sort_key(release: Release) -> Tuple:
+        """Return a deterministic newest-first sorting key for a release."""
+        return (
+            release.version.sort_key,
+            release.distribution.is_default,
+            release.distribution.type.value,
+            release.distribution.name,
+            release.commit,
+        )
+
+    @staticmethod
+    def _find_distro_alias_owners(releases: List[Release]) -> Dict[str, Release]:
+        """Find the highest GA release supporting each distro tag name."""
+        owners: Dict[str, Release] = {}
+
+        for release in releases:
+            if release.version.is_milestone:
+                continue
+
+            for distro_name in release.distribution.tag_names:
+                current_owner = owners.get(distro_name)
+                if (
+                    current_owner is None
+                    or release.version.sort_key > current_owner.version.sort_key
+                ):
+                    owners[distro_name] = release
+
+        return owners
+
     def generate_stackbrew_library(
         self,
         releases: List[Release],
-        enable_global_latest_tags: bool = True,
+        emit_global_latest: bool = True,
+        emit_bare_aliases: bool = True,
     ) -> List[StackbrewEntry]:
         """Generate stackbrew library entries from releases.
 
         Args:
             releases: List of releases to process
-            enable_global_latest_tags: Whether to emit latest/bare distro tags
+            emit_global_latest: Whether to emit the global "latest" alias
+            emit_bare_aliases: Whether to emit bare distro aliases
 
         Returns:
             List of StackbrewEntry objects
@@ -111,49 +143,50 @@ class StackbrewGenerator:
             return []
 
         entries = []
-        latest_minor = None
-        latest_minor_unset = True
-        seen_distro_tag_names: Set[str] = set()
+        ordered_releases = sorted(
+            releases,
+            key=self._release_sort_key,
+            reverse=True,
+        )
+        ga_versions = [
+            release.version
+            for release in ordered_releases
+            if not release.version.is_milestone
+        ]
+        latest_ga_version = max(
+            ga_versions,
+            key=lambda version: version.sort_key,
+            default=None,
+        )
+        distro_alias_owners = self._find_distro_alias_owners(ordered_releases)
 
-        for release in releases:
-            # Determine latest version following bash logic:
-            # - Set latest_minor to the minor version of the first non-milestone version
-            # - Clear latest_minor if subsequent versions have different minor versions
-            if latest_minor_unset:
-                if not release.version.is_milestone:
-                    latest_minor = release.version.minor
-                    latest_minor_unset = False
-                    console.print(f"[dim]Latest minor version set to: {latest_minor}[/dim]")
-            elif latest_minor != release.version.minor:
-                latest_minor = None
+        if latest_ga_version is not None:
+            console.print(
+                f"[dim]Latest minor version set to: {latest_ga_version.minor}[/dim]"
+            )
 
-            # Major tag like "7" still belongs to the latest active minor within the major.
-            is_latest_in_major = latest_minor is not None
-            # Global tags like "latest" or bare distro names should only be emitted
-            # for the highest overall major version.
-            is_global_latest_major = enable_global_latest_tags and is_latest_in_major
-
-            # Distro aliases belong to the first GA release that supports each
-            # distro name. Releases are ordered newest first, so older maintained
-            # distros retain their aliases without taking global aliases such as
-            # the unqualified major or "latest" from the newest release.
-            latest_distro_tag_names = set()
-            bare_distro_tag_names = set()
-            if not release.version.is_milestone:
-                for distro_name in release.distribution.tag_names:
-                    if distro_name not in seen_distro_tag_names:
-                        latest_distro_tag_names.add(distro_name)
-                        if enable_global_latest_tags:
-                            bare_distro_tag_names.add(distro_name)
-                        seen_distro_tag_names.add(distro_name)
+        for release in ordered_releases:
+            is_latest_minor = (
+                latest_ga_version is not None
+                and not release.version.is_milestone
+                and release.version.minor == latest_ga_version.minor
+            )
+            major_alias_distro_names = {
+                distro_name
+                for distro_name in release.distribution.tag_names
+                if distro_alias_owners.get(distro_name) is release
+            }
+            bare_alias_distro_names = (
+                major_alias_distro_names if emit_bare_aliases else set()
+            )
 
             # Generate tags for this release
             tags = self.generate_tags_for_release(
                 release,
-                is_latest_in_major=is_latest_in_major,
-                is_global_latest_major=is_global_latest_major,
-                latest_distro_tag_names=latest_distro_tag_names,
-                bare_distro_tag_names=bare_distro_tag_names,
+                is_latest_minor=is_latest_minor,
+                emit_global_latest=emit_global_latest and is_latest_minor,
+                major_alias_distro_names=major_alias_distro_names,
+                bare_alias_distro_names=bare_alias_distro_names,
             )
 
             if tags:

--- a/release-automation/src/stackbrew_generator/stackbrew.py
+++ b/release-automation/src/stackbrew_generator/stackbrew.py
@@ -20,6 +20,7 @@ class StackbrewGenerator:
         is_latest_in_major: bool = False,
         is_global_latest_major: bool = False,
         latest_distro_tag_names: Optional[Set[str]] = None,
+        bare_distro_tag_names: Optional[Set[str]] = None,
     ) -> List[str]:
         """Generate Docker tags for a release.
 
@@ -29,6 +30,7 @@ class StackbrewGenerator:
             is_global_latest_major: Whether this major is the highest active major overall
             latest_distro_tag_names: Distro tag names whose major aliases belong to
                 this release
+            bare_distro_tag_names: Bare distro aliases that belong to this release
 
         Returns:
             List of Docker tags
@@ -57,6 +59,10 @@ class StackbrewGenerator:
             latest_distro_tag_names = (
                 set(distribution.tag_names) if is_latest_in_major else set()
             )
+        if bare_distro_tag_names is None:
+            bare_distro_tag_names = (
+                set(distribution.tag_names) if is_global_latest_major else set()
+            )
 
         # For default distribution (Debian), add version tags without distro suffix
         if distribution.is_default:
@@ -71,12 +77,16 @@ class StackbrewGenerator:
             for version_tag in distro_version_tags:
                 tags.append(f"{version_tag}-{distro_name}")
 
-        # Add global latest tags only for the highest overall major version
-        if is_global_latest_major:
-            if distribution.is_default:
-                tags.append("latest")
-            # Add bare distro names as tags
-            tags.extend(distribution.tag_names)
+        # The global "latest" alias remains on the newest default image only.
+        if is_global_latest_major and distribution.is_default:
+            tags.append("latest")
+
+        # Bare distro aliases belong to the newest release supporting each distro.
+        tags.extend(
+            distro_name
+            for distro_name in distribution.tag_names
+            if distro_name in bare_distro_tag_names
+        )
 
         return tags
 
@@ -103,7 +113,7 @@ class StackbrewGenerator:
         entries = []
         latest_minor = None
         latest_minor_unset = True
-        seen_debian_distro_tag_names: Set[str] = set()
+        seen_distro_tag_names: Set[str] = set()
 
         for release in releases:
             # Determine latest version following bash logic:
@@ -123,20 +133,19 @@ class StackbrewGenerator:
             # for the highest overall major version.
             is_global_latest_major = enable_global_latest_tags and is_latest_in_major
 
-            # A Debian suite-qualified major tag (for example, "8-bookworm")
-            # belongs to the first GA release that supports that suite. Releases
-            # are ordered newest first, so later releases can retain their suite
-            # aliases without taking global aliases from the newest release.
+            # Distro aliases belong to the first GA release that supports each
+            # distro name. Releases are ordered newest first, so older maintained
+            # distros retain their aliases without taking global aliases such as
+            # the unqualified major or "latest" from the newest release.
             latest_distro_tag_names = set()
-            if not release.version.is_milestone and release.distribution.is_default:
+            bare_distro_tag_names = set()
+            if not release.version.is_milestone:
                 for distro_name in release.distribution.tag_names:
-                    if distro_name not in seen_debian_distro_tag_names:
+                    if distro_name not in seen_distro_tag_names:
                         latest_distro_tag_names.add(distro_name)
-                        seen_debian_distro_tag_names.add(distro_name)
-            elif is_latest_in_major:
-                # Preserve the existing Alpine behavior: its major aliases belong
-                # to the globally latest minor only.
-                latest_distro_tag_names = set(release.distribution.tag_names)
+                        if enable_global_latest_tags:
+                            bare_distro_tag_names.add(distro_name)
+                        seen_distro_tag_names.add(distro_name)
 
             # Generate tags for this release
             tags = self.generate_tags_for_release(
@@ -144,6 +153,7 @@ class StackbrewGenerator:
                 is_latest_in_major=is_latest_in_major,
                 is_global_latest_major=is_global_latest_major,
                 latest_distro_tag_names=latest_distro_tag_names,
+                bare_distro_tag_names=bare_distro_tag_names,
             )
 
             if tags:

--- a/release-automation/src/stackbrew_generator/stackbrew.py
+++ b/release-automation/src/stackbrew_generator/stackbrew.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Set
 
 from rich.console import Console
 
@@ -19,6 +19,7 @@ class StackbrewGenerator:
         release: Release,
         is_latest_in_major: bool = False,
         is_global_latest_major: bool = False,
+        latest_distro_tag_names: Optional[Set[str]] = None,
     ) -> List[str]:
         """Generate Docker tags for a release.
 
@@ -26,6 +27,8 @@ class StackbrewGenerator:
             release: Release to generate tags for
             is_latest_in_major: Whether this is the latest active minor in its major
             is_global_latest_major: Whether this major is the highest active major overall
+            latest_distro_tag_names: Distro tag names whose major aliases belong to
+                this release
 
         Returns:
             List of Docker tags
@@ -41,17 +44,31 @@ class StackbrewGenerator:
         if not version.is_milestone:
             version_tags.append(version.mainline_version)
 
-        # Add major version tag for latest versions
+        # Keep the global major alias separate from the distro-qualified aliases.
+        # This lets an older maintained distro release own (for example)
+        # "8-bookworm" without also owning the unqualified "8" tag.
+        default_version_tags = version_tags.copy()
         if is_latest_in_major:
-            version_tags.append(str(version.major))
+            default_version_tags.append(str(version.major))
+
+        # Preserve the direct-call behavior used by existing callers and tests:
+        # a release that is globally latest owns all of its distro major aliases.
+        if latest_distro_tag_names is None:
+            latest_distro_tag_names = (
+                set(distribution.tag_names) if is_latest_in_major else set()
+            )
 
         # For default distribution (Debian), add version tags without distro suffix
         if distribution.is_default:
-            tags.extend(version_tags)
+            tags.extend(default_version_tags)
 
         # Add distro-specific tags
         for distro_name in distribution.tag_names:
-            for version_tag in version_tags:
+            distro_version_tags = version_tags.copy()
+            if distro_name in latest_distro_tag_names:
+                distro_version_tags.append(str(version.major))
+
+            for version_tag in distro_version_tags:
                 tags.append(f"{version_tag}-{distro_name}")
 
         # Add global latest tags only for the highest overall major version
@@ -86,6 +103,7 @@ class StackbrewGenerator:
         entries = []
         latest_minor = None
         latest_minor_unset = True
+        seen_debian_distro_tag_names: Set[str] = set()
 
         for release in releases:
             # Determine latest version following bash logic:
@@ -105,11 +123,27 @@ class StackbrewGenerator:
             # for the highest overall major version.
             is_global_latest_major = enable_global_latest_tags and is_latest_in_major
 
+            # A Debian suite-qualified major tag (for example, "8-bookworm")
+            # belongs to the first GA release that supports that suite. Releases
+            # are ordered newest first, so later releases can retain their suite
+            # aliases without taking global aliases from the newest release.
+            latest_distro_tag_names = set()
+            if not release.version.is_milestone and release.distribution.is_default:
+                for distro_name in release.distribution.tag_names:
+                    if distro_name not in seen_debian_distro_tag_names:
+                        latest_distro_tag_names.add(distro_name)
+                        seen_debian_distro_tag_names.add(distro_name)
+            elif is_latest_in_major:
+                # Preserve the existing Alpine behavior: its major aliases belong
+                # to the globally latest minor only.
+                latest_distro_tag_names = set(release.distribution.tag_names)
+
             # Generate tags for this release
             tags = self.generate_tags_for_release(
                 release,
                 is_latest_in_major=is_latest_in_major,
                 is_global_latest_major=is_global_latest_major,
+                latest_distro_tag_names=latest_distro_tag_names,
             )
 
             if tags:

--- a/release-automation/tests/test_stackbrew.py
+++ b/release-automation/tests/test_stackbrew.py
@@ -19,8 +19,8 @@ class TestStackbrewGenerator:
 
         tags = self.generator.generate_tags_for_release(
             release,
-            is_latest_in_major=True,
-            is_global_latest_major=True,
+            is_latest_minor=True,
+            emit_global_latest=True,
         )
 
         expected_tags = [
@@ -44,8 +44,8 @@ class TestStackbrewGenerator:
 
         tags = self.generator.generate_tags_for_release(
             release,
-            is_latest_in_major=False,
-            is_global_latest_major=False,
+            is_latest_minor=False,
+            emit_global_latest=False,
         )
 
         expected_tags = [
@@ -65,8 +65,8 @@ class TestStackbrewGenerator:
 
         tags = self.generator.generate_tags_for_release(
             release,
-            is_latest_in_major=True,
-            is_global_latest_major=True,
+            is_latest_minor=True,
+            emit_global_latest=True,
         )
 
         expected_tags = [
@@ -90,8 +90,8 @@ class TestStackbrewGenerator:
 
         tags = self.generator.generate_tags_for_release(
             release,
-            is_latest_in_major=False,
-            is_global_latest_major=False,
+            is_latest_minor=False,
+            emit_global_latest=False,
         )
 
         # Milestone versions should not get mainline version tags or major version tags
@@ -251,9 +251,17 @@ class TestStackbrewGenerator:
             "8.2-alpine3.22",
         ]
 
+        shuffled_entries = self.generator.generate_stackbrew_library(
+            [releases[index] for index in (4, 2, 0, 3, 1)]
+        )
+        assert self.generator.format_stackbrew_output(
+            shuffled_entries
+        ) == self.generator.format_stackbrew_output(entries)
+
         non_global_entries = self.generator.generate_stackbrew_library(
             releases,
-            enable_global_latest_tags=False,
+            emit_global_latest=False,
+            emit_bare_aliases=False,
         )
         assert all("latest" not in entry.tags for entry in non_global_entries)
         assert all(
@@ -263,6 +271,27 @@ class TestStackbrewGenerator:
         )
         assert any("8-bookworm" in entry.tags for entry in non_global_entries)
         assert any("8-alpine3.22" in entry.tags for entry in non_global_entries)
+
+        bare_only_entries = self.generator.generate_stackbrew_library(
+            releases,
+            emit_global_latest=False,
+            emit_bare_aliases=True,
+        )
+        assert all("latest" not in entry.tags for entry in bare_only_entries)
+        assert any("bookworm" in entry.tags for entry in bare_only_entries)
+        assert any("alpine3.22" in entry.tags for entry in bare_only_entries)
+
+        latest_only_entries = self.generator.generate_stackbrew_library(
+            releases,
+            emit_global_latest=True,
+            emit_bare_aliases=False,
+        )
+        assert any("latest" in entry.tags for entry in latest_only_entries)
+        assert all(
+            distro_name not in entry.tags
+            for entry in latest_only_entries
+            for distro_name in entry.distribution.tag_names
+        )
 
     def test_format_stackbrew_output(self):
         """Test stackbrew output formatting."""

--- a/release-automation/tests/test_stackbrew.py
+++ b/release-automation/tests/test_stackbrew.py
@@ -142,7 +142,7 @@ class TestStackbrewGenerator:
         assert "8" not in debian_8_1_5.tags
 
     def test_generate_stackbrew_library_assigns_major_aliases_per_distro_tag(self):
-        """Keep global aliases global while retaining the Bookworm major alias."""
+        """Assign moving aliases to the newest release for each distro name."""
         releases = [
             Release(
                 commit="trixie-debian",
@@ -151,9 +151,27 @@ class TestStackbrewGenerator:
                 git_fetch_ref="refs/tags/v8.10.1",
             ),
             Release(
+                commit="alpine-3.23",
+                version=RedisVersion.parse("8.10.1"),
+                distribution=Distribution(type=DistroType.ALPINE, name="alpine3.23"),
+                git_fetch_ref="refs/tags/v8.10.1",
+            ),
+            Release(
+                commit="alpine-3.22-current",
+                version=RedisVersion.parse("8.4.6"),
+                distribution=Distribution(type=DistroType.ALPINE, name="alpine3.22"),
+                git_fetch_ref="refs/tags/v8.4.6",
+            ),
+            Release(
                 commit="bookworm-debian",
                 version=RedisVersion.parse("8.2.9"),
                 distribution=Distribution(type=DistroType.DEBIAN, name="bookworm"),
+                git_fetch_ref="refs/tags/v8.2.9",
+            ),
+            Release(
+                commit="alpine-3.22-older",
+                version=RedisVersion.parse("8.2.9"),
+                distribution=Distribution(type=DistroType.ALPINE, name="alpine3.22"),
                 git_fetch_ref="refs/tags/v8.2.9",
             ),
         ]
@@ -172,6 +190,24 @@ class TestStackbrewGenerator:
             if entry.distribution.type == DistroType.DEBIAN
             and entry.distribution.name == "bookworm"
         )
+        alpine_3_23 = next(
+            entry
+            for entry in entries
+            if entry.version.minor == 10
+            and entry.distribution.type == DistroType.ALPINE
+        )
+        alpine_3_22_current = next(
+            entry
+            for entry in entries
+            if entry.version.minor == 4
+            and entry.distribution.type == DistroType.ALPINE
+        )
+        alpine_3_22_older = next(
+            entry
+            for entry in entries
+            if entry.version.minor == 2
+            and entry.distribution.type == DistroType.ALPINE
+        )
         assert trixie.tags == [
             "8.10.1",
             "8.10",
@@ -188,7 +224,45 @@ class TestStackbrewGenerator:
             "8.2.9-bookworm",
             "8.2-bookworm",
             "8-bookworm",
+            "bookworm",
         ]
+        assert alpine_3_23.tags == [
+            "8.10.1-alpine",
+            "8.10-alpine",
+            "8-alpine",
+            "8.10.1-alpine3.23",
+            "8.10-alpine3.23",
+            "8-alpine3.23",
+            "alpine",
+            "alpine3.23",
+        ]
+        assert alpine_3_22_current.tags == [
+            "8.4.6-alpine",
+            "8.4-alpine",
+            "8.4.6-alpine3.22",
+            "8.4-alpine3.22",
+            "8-alpine3.22",
+            "alpine3.22",
+        ]
+        assert alpine_3_22_older.tags == [
+            "8.2.9-alpine",
+            "8.2-alpine",
+            "8.2.9-alpine3.22",
+            "8.2-alpine3.22",
+        ]
+
+        non_global_entries = self.generator.generate_stackbrew_library(
+            releases,
+            enable_global_latest_tags=False,
+        )
+        assert all("latest" not in entry.tags for entry in non_global_entries)
+        assert all(
+            distro_name not in entry.tags
+            for entry in non_global_entries
+            for distro_name in entry.distribution.tag_names
+        )
+        assert any("8-bookworm" in entry.tags for entry in non_global_entries)
+        assert any("8-alpine3.22" in entry.tags for entry in non_global_entries)
 
     def test_format_stackbrew_output(self):
         """Test stackbrew output formatting."""
@@ -260,7 +334,7 @@ class TestStackbrewGenerator:
             ["8.2.1", "8.2", "8", "8.2.1-bookworm", "8.2-bookworm", "8-bookworm", "latest", "bookworm"],  # GA - gets all tags
             ["8.2.1-alpine", "8.2-alpine", "8-alpine", "8.2.1-alpine3.22", "8.2-alpine3.22", "8-alpine3.22", "alpine", "alpine3.22"],  # GA - gets all tags
             ["8.0.3", "8.0", "8.0.3-bookworm", "8.0-bookworm"],  # different minor - no major tags
-            ["8.0.3-alpine", "8.0-alpine", "8.0.3-alpine3.21", "8.0-alpine3.21"]  # different minor - no major tags
+            ["8.0.3-alpine", "8.0-alpine", "8.0.3-alpine3.21", "8.0-alpine3.21", "8-alpine3.21", "alpine3.21"]  # newest release for Alpine 3.21
         ]
 
         assert len(entries) == 6

--- a/release-automation/tests/test_stackbrew.py
+++ b/release-automation/tests/test_stackbrew.py
@@ -141,6 +141,55 @@ class TestStackbrewGenerator:
         assert "latest" not in debian_8_1_5.tags
         assert "8" not in debian_8_1_5.tags
 
+    def test_generate_stackbrew_library_assigns_major_aliases_per_distro_tag(self):
+        """Keep global aliases global while retaining the Bookworm major alias."""
+        releases = [
+            Release(
+                commit="trixie-debian",
+                version=RedisVersion.parse("8.10.1"),
+                distribution=Distribution(type=DistroType.DEBIAN, name="trixie"),
+                git_fetch_ref="refs/tags/v8.10.1",
+            ),
+            Release(
+                commit="bookworm-debian",
+                version=RedisVersion.parse("8.2.9"),
+                distribution=Distribution(type=DistroType.DEBIAN, name="bookworm"),
+                git_fetch_ref="refs/tags/v8.2.9",
+            ),
+        ]
+
+        entries = self.generator.generate_stackbrew_library(releases)
+
+        trixie = next(
+            entry
+            for entry in entries
+            if entry.distribution.type == DistroType.DEBIAN
+            and entry.distribution.name == "trixie"
+        )
+        bookworm = next(
+            entry
+            for entry in entries
+            if entry.distribution.type == DistroType.DEBIAN
+            and entry.distribution.name == "bookworm"
+        )
+        assert trixie.tags == [
+            "8.10.1",
+            "8.10",
+            "8",
+            "8.10.1-trixie",
+            "8.10-trixie",
+            "8-trixie",
+            "latest",
+            "trixie",
+        ]
+        assert bookworm.tags == [
+            "8.2.9",
+            "8.2",
+            "8.2.9-bookworm",
+            "8.2-bookworm",
+            "8-bookworm",
+        ]
+
     def test_format_stackbrew_output(self):
         """Test stackbrew output formatting."""
         entries = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes published Docker tag mapping for stackbrew output; wrong alias ownership would misdirect pulls, but behavior is covered by expanded unit tests.
> 
> **Overview**
> **Fixes moving Docker tags** (`8-bookworm`, `alpine3.22`, bare distro names) so they point at the **newest GA release that still ships each distro**, instead of tying all major aliases to a single “latest minor” line.
> 
> Tag generation now **splits the unqualified major tag** (`8`) from **distro-qualified majors** (`8-bookworm`). The latest minor still gets global `8` and `latest` on the default image; **per-distro majors and bare aliases** are computed via `_find_distro_alias_owners` over sorted releases (order-independent).
> 
> The CLI replaces `enable_global_latest_tags` with **`emit_global_latest`** and **`emit_bare_aliases`**, both enabled only when generating the highest remote GA major.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6595fee6495c97ad567eb653714b798298df26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->